### PR TITLE
Force structures to be Copy instead of Clone

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@
 //!
 //! // `Clone` is required for `RdxSort`
 //! // `PartialEq` is only required for the equality assert, not for the actual sorting
-//! #[derive(Clone, PartialEq)]
+//! #[derive(Copy, Clone, PartialEq)]
 //! struct Foo {
 //!     a: u8,
 //!     b: u8,

--- a/src/sort.rs
+++ b/src/sort.rs
@@ -27,7 +27,7 @@ fn helper_bucket<T, I>(buckets_b: &mut Vec<Vec<T>>, iter: I, cfg_nbuckets: usize
 }
 
 impl<T> RdxSort for [T]
-    where T: Rdx + Clone
+    where T: Rdx + Copy
 {
     fn rdxsort(&mut self) {
         // config
@@ -94,7 +94,7 @@ impl<T> RdxSort for [T]
 }
 
 impl<T> RdxSort for Vec<T>
-    where [T]: RdxSort
+    where T: Rdx + Copy
 {
     fn rdxsort(&mut self) {
         self.as_mut_slice().rdxsort();


### PR DESCRIPTION
I fixed a bug related to unsafe code inside the `RdxSort::rdxsort` slice implementation where you used the unsafe `copy_nonoverlapping` function on `Clone` restricted types, which is not enough to be safe.

https://github.com/crepererum/rdxsort-rs/blob/c6549712cb893cd8a7e4ad24f101db06e186ed7e/src/sort.rs#L83-L87

As [the function documentation](https://doc.rust-lang.org/std/ptr/fn.copy_nonoverlapping.html) warns us:

> If `T` is not `Copy`, using _both_ the values in the region beginning at `*src` and the region beginning at `*dst` can violate memory safety.

As a good example we can just take reference counted types that **must** increment a counter when cloned and decrement it when dropped, in this case you just use `memcpy` internally on the `Rc` structure that does not inform the type that it has been cloned **but** before that you used `iter().cloned()` on these same structs.

https://github.com/crepererum/rdxsort-rs/blob/c6549712cb893cd8a7e4ad24f101db06e186ed7e/src/sort.rs#L51

It is not safe because it could generate use-after-free bugs, the `Rc` is previously cloned, incrementing the internal counter, copied without incrementing it (the pointer to the data is copied without being tracked by the counter) and dropped so decrementing the counter which can trigger the drop function, the memory area where the copy has been made can contain pointers to freed data.

So solutions to fix this bug could be either:
 - to restrict the `T` type to be `Copy` therefore this function call can be considered "safe"
 - to use another unsafe call to forget some buckets elements ([`Vec::set_len`](https://doc.rust-lang.org/stable/std/vec/struct.Vec.html#method.set_len))